### PR TITLE
Todos los controladores requieren autenticación for default

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -44,6 +44,7 @@ gem "thruster", require: false
 gem "image_processing", "~> 1.2"
 
 gem "meta-tags"
+gem "mission_control-jobs", "~> 0.3.1"
 gem "pagy", "~> 8.4"
 gem "rack-attack"
 gem "rails-i18n", "~> 7.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -178,6 +178,12 @@ GEM
     mini_mime (1.1.5)
     mini_portile2 (2.8.7)
     minitest (5.25.1)
+    mission_control-jobs (0.3.1)
+      importmap-rails
+      irb (~> 1.13)
+      rails (>= 7.1)
+      stimulus-rails
+      turbo-rails
     msgpack (1.7.2)
     net-imap (0.4.16)
       date
@@ -408,6 +414,7 @@ DEPENDENCIES
   kamal (>= 2.0.0.rc2)
   letter_opener
   meta-tags
+  mission_control-jobs (~> 0.3.1)
   newrelic_rpm
   pagy (~> 8.4)
   propshaft

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2,10 +2,16 @@ class ApplicationController < ActionController::Base
   include Pagy::Backend
   include SwitchLocale
 
+  before_action :authenticate_user!
+
   # Only allow modern browsers supporting webp images, web push, badges, import maps, CSS nesting, and CSS :has.
   # allow_browser versions: :modern
 
-  private
+  def self.allow_unauthenticated_access(**)
+    skip_before_action(:authenticate_user!, **)
+  end
+
+  protected
 
   def authenticate_user!
     redirect_to new_sessions_path unless current_user
@@ -20,6 +26,8 @@ class ApplicationController < ActionController::Base
   end
 
   helper_method :current_user, :user_signed_in?
+
+  private
 
   def authenticate_from_session
     User.find_by(id: session[:user_id])

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -1,4 +1,5 @@
 class HomeController < ApplicationController
+  allow_unauthenticated_access
   include JsonLdGenerator
   include MetaTagsGenerator
 

--- a/app/controllers/rss_controller.rb
+++ b/app/controllers/rss_controller.rb
@@ -1,4 +1,6 @@
 class RssController < ApplicationController
+  allow_unauthenticated_access
+
   def index
     @photos = Photo.published
       .with_rich_text_description.with_attached_image

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -1,4 +1,5 @@
 class SessionsController < ApplicationController
+  allow_unauthenticated_access
   rate_limit to: 4, within: 1.minute
 
   layout "security"

--- a/app/controllers/sitemap_controller.rb
+++ b/app/controllers/sitemap_controller.rb
@@ -1,4 +1,6 @@
 class SitemapController < ApplicationController
+  allow_unauthenticated_access
+
   def index
     @photos = Photo.published
       .with_rich_text_description.with_attached_image

--- a/app/jobs/publish_photo_job.rb
+++ b/app/jobs/publish_photo_job.rb
@@ -2,6 +2,9 @@ class PublishPhotoJob < ApplicationJob
   queue_as :default
 
   def perform
+    last_published_at = Photo.published.last&.published_at
+    return if Time.zone.now.hour.between?(9, 18) && (last_published_at && last_published_at < 2.hours.ago)
+
     photo = Photo.unpublished.order(created_at: :asc).first
     return unless photo
 

--- a/config/recurring.yml
+++ b/config/recurring.yml
@@ -6,4 +6,5 @@ publish_photo:
   class: PublishPhotoJob
   queue: default
   args: []
-  schedule: "0 */2 9-17 * *"
+  schedule: every 15 minutes
+  priority: 1

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -17,6 +17,9 @@ Rails.application.routes.draw do
     resources :photos, except: [:show, :destroy]
   end
 
+  scope "/admin" do
+    mount MissionControl::Jobs::Engine, at: "/jobs"
+  end
   get "/admin" => "admin/photos#index"
 
   resource :about, controller: :about, only: [:show]


### PR DESCRIPTION
- Si hay controladores públicos, entonces tiene que permitir explícitamente acceso sin autenticación
- Agrega Mission Control para Jobs
- Cambia la lógica del PublishPhotoJob